### PR TITLE
TF-853: Gripper cannot hang in a reset()

### DIFF
--- a/robotiq_c_model_control/src/robotiq_c_model_control/robotiq_gripper_action_interface.py
+++ b/robotiq_c_model_control/src/robotiq_c_model_control/robotiq_gripper_action_interface.py
@@ -27,13 +27,15 @@ fault_text = {'/0x05': 'Action delayed, activation (reactivation) must be comple
               '/0x0F': 'Automatic release completed.',
               }
 
+
 class RobotiqCommandTimeout(object):
     """Track command timeouts."""
     def __init__(self, seconds):
         """Create a command timer.
 
         Args:
-            seconds = timeout duration in seconds
+            :param seconds: timeout duration in seconds
+            :type seconds: float
         """
         super(RobotiqCommandTimeout, self).__init__()
         self.start_time = rospy.get_rostime()
@@ -66,7 +68,9 @@ class RobotiqGripperActionInterface(BaseCModel):
         """Convert Gripper response status into a string.
 
         Args:
-            status (CModel_robot_input): the status registers from the gripper.
+            :param status: the status registers from the gripper.
+            :type status: CModel_robot_input
+        Return: str
         """
         return 'gACT:{}, gGTO:{}, gSTA:{}, gOBJ:{}, ' \
                'gFLT:{}, gPR:{}, gPO:{}, gCU:{}'.format(
@@ -285,8 +289,10 @@ class RobotiqGripperActionInterface(BaseCModel):
         Send a calibration command to the gripper and wait for the next status after completion.
 
         Args:
-            direction (GripperGoal direction): gripper open/close
-            wait_seconds: time in seconds before getting a status update.
+            :param direction: gripper open/close
+            :type direction GripperGoal direction
+            :param wait_seconds: time in seconds before getting a status update.
+            :type wait_seconds: float
         Returns:
             True if command sent correctly.
         """

--- a/robotiq_c_model_control/src/robotiq_c_model_control/robotiq_gripper_action_interface.py
+++ b/robotiq_c_model_control/src/robotiq_c_model_control/robotiq_gripper_action_interface.py
@@ -27,6 +27,30 @@ fault_text = {'/0x05': 'Action delayed, activation (reactivation) must be comple
               '/0x0F': 'Automatic release completed.',
               }
 
+class RobotiqCommandTimeout(object):
+    """Track command timeouts."""
+    def __init__(self, seconds):
+        """Create a command timer.
+
+        Args:
+            seconds = timeout duration in seconds
+        """
+        super(RobotiqCommandTimeout, self).__init__()
+        self.start_time = rospy.get_rostime()
+        self.duration = rospy.Duration(seconds)
+
+    def start(self):
+        """Start the timer."""
+        self.start_time = rospy.get_rostime()
+
+    def expired(self):
+        """Check if the timer has expired.
+
+        Returns:
+            True if timeout is expired
+        """
+        return rospy.get_rostime() - self.start_time > self.duration
+
 
 @ready_logging.logged
 class RobotiqGripperActionInterface(BaseCModel):
@@ -36,6 +60,25 @@ class RobotiqGripperActionInterface(BaseCModel):
     has_goal_lock = Lock()
     interrupt_lock = Lock()
     resetting_lock = Lock()
+
+    @staticmethod
+    def grip_status_to_str(status):
+        """Convert Gripper response status into a string.
+
+        Args:
+            status (CModel_robot_input): the status registers from the gripper.
+        """
+        return 'gACT:{}, gGTO:{}, gSTA:{}, gOBJ:{}, ' \
+               'gFLT:{}, gPR:{}, gPO:{}, gCU:{}'.format(
+                       status.gACT,
+                       status.gGTO,
+                       status.gSTA,
+                       status.gOBJ,
+                       status.gFLT,
+                       status.gPR,
+                       status.gPO,
+                       status.gCU
+                       )
 
     @property
     def has_goal(self):
@@ -236,6 +279,29 @@ class RobotiqGripperActionInterface(BaseCModel):
         self.reset_thread = Thread(target=self.reset, name='Robotiq Gripper Reset Thread')
         self.reset_thread.start()
 
+    def do_calibration_move(self, direction=GripperGoal.OPEN, wait_seconds=1.25):
+        """Do a calibration command.
+
+        Send a calibration command to the gripper and wait for the next status after completion.
+
+        Args:
+            direction (GripperGoal direction): gripper open/close
+            wait_seconds: time in seconds before getting a status update.
+        Returns:
+            True if command sent correctly.
+        """
+        goal = GripperGoal()
+        goal.force = 255
+        goal.direction = direction
+        goal.auto_release = goal.DISABLED
+        sent = self.send_gripper_command(goal)
+        if sent:
+            rospy.sleep(wait_seconds)
+            with self.status_cv:
+                self.status_cv.wait(0.25)
+                self.max_closed = self.last_status.gPO
+        return sent
+
     def reset(self):
         # Reset the gripper during startup or after a fault. A specific order of states must be sent to the gripper.
         # We recalibrate after reset to be thorough.
@@ -258,11 +324,19 @@ class RobotiqGripperActionInterface(BaseCModel):
             goal = CModel_robot_output()
             goal.rACT = 0
             self.send_gripper_command(goal, parse=False)
+
+            # Wait for the gripper to deactivate
+            timer = RobotiqCommandTimeout(seconds=3.0)
+            timer.start()
             while not rospy.is_shutdown() and not self.interrupted:
                 with self.status_cv:
                     self.status_cv.wait(0.25)
                     status = deepcopy(self.last_status)
                 if status.gSTA == 0:
+                    break
+                if timer.expired():
+                    self.__log.err('Timeout on deactivate w/ status: "{}"'.format(self.grip_status_to_str(status)))
+                    rospy.signal_shutdown('Failed to Deactivate Gripper -- timeout')
                     break
 
             if rospy.is_shutdown():
@@ -274,11 +348,19 @@ class RobotiqGripperActionInterface(BaseCModel):
         goal = CModel_robot_output()
         goal.rACT = 1
         self.send_gripper_command(goal, parse=False)
+
+        # Wait for gripper to activate
+        timer = RobotiqCommandTimeout(seconds=3.0)
+        timer.start()
         while not rospy.is_shutdown() and not self.interrupted:
             with self.status_cv:
                 self.status_cv.wait(0.25)
                 status = deepcopy(self.last_status)
             if status.gSTA == 3:
+                break
+            if timer.expired():
+                self.__log.err('Timeout on activate w/ status: "{}"'.format(self.grip_status_to_str(status)))
+                rospy.signal_shutdown('Failed to Activate Gripper -- timeout')
                 break
 
         if rospy.is_shutdown():
@@ -287,36 +369,20 @@ class RobotiqGripperActionInterface(BaseCModel):
             return
 
         rospy.sleep(1.0)
-        # Get Actual Calibrated Values
-        goal = GripperGoal()
-        goal.force = 255
-        goal.direction = goal.CLOSE
-        goal.auto_release = goal.DISABLED
-        if not self.send_gripper_command(goal):
+
+        if not self.do_calibration_move(GripperGoal.CLOSE, wait_seconds=1.25):
             self.has_goal = False
             self.resetting = False
+            self.__log.err('Could not send calibration close command.')
             rospy.signal_shutdown('Failed Close Calibration')
             return
 
-        rospy.sleep(1.25)
-        with self.status_cv:
-            self.status_cv.wait(0.25)
-            self.max_closed = self.last_status.gPO
-
-        goal = GripperGoal()
-        goal.force = 255
-        goal.direction = goal.OPEN
-        goal.auto_release = goal.DISABLED
-        if not self.send_gripper_command(goal):
+        if not self.do_calibration_move(GripperGoal.OPEN, wait_seconds=1.25):
             self.has_goal = False
             self.resetting = False
+            self.__log.err('Could not send calibration open command.')
             rospy.signal_shutdown('Failed Open Calibration')
             return
-
-        rospy.sleep(1.25)
-        with self.status_cv:
-            self.status_cv.wait(0.25)
-            self.max_open = self.last_status.gPO
 
         self.has_goal = False
         self.resetting = False


### PR DESCRIPTION
Added fixed limit timeouts to each of the grip commands. A couple commands
waited indefinitely for a given set of register results. In these cases the
reset would never complete.

It is possible to send the correct command to the gripper and never receive the
expected result. It seems to be an issue on the Robotiq side.

As a concrete example I observed the gripper fail to complete the activate
command (rACT=1). The queried status from the Robotiq gripper was:

gACT:1, gGTO:0, gSTA:0, gOBJ:0, gFLT:0, gPR:0, gPO:3, gCU:0

According to the documentation on Robotiq's website, a gACT:1 with gSTA:0
implies a fault has occurred. Unfortunately for us the gFLT register contains
exactly zero useful information about what caused the fault.that waits
indefinitely for a given