### PR TITLE
TF-3789: Cleanup + Launch_manager support

### DIFF
--- a/robotiq_force_torque_sensor/CMakeLists.txt
+++ b/robotiq_force_torque_sensor/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_force_torque_sensor)
 
+# "-Werror" removed since the code originates as thrid party and can't compile with it added
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   bondcpp

--- a/robotiq_force_torque_sensor/CMakeLists.txt
+++ b/robotiq_force_torque_sensor/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_force_torque_sensor)
 
-# "-Werror" removed since the code originates as thrid party and can't compile with it added
+# "-Werror" removed since the code originates as third party and can't compile with it added
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_STANDARD 11)
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   bondcpp
+  launch_manager_interface
   std_msgs
   message_generation
 )
@@ -40,7 +41,10 @@ generate_messages(
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-  CATKIN_DEPENDS message_runtime std_msgs
+  CATKIN_DEPENDS
+    message_runtime
+    std_msgs
+    launch_manager_interface
 )
 
 ###########

--- a/robotiq_force_torque_sensor/nodes/rq_sensor.cpp
+++ b/robotiq_force_torque_sensor/nodes/rq_sensor.cpp
@@ -1,37 +1,38 @@
 /* Software License Agreement (BSD License)
-*
-* Copyright (c) 2014, Robotiq, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions
-* are met:
-*
-* * Redistributions of source code must retain the above copyright
-* notice, this list of conditions and the following disclaimer.
-* * Redistributions in binary form must reproduce the above
-* copyright notice, this list of conditions and the following
-* disclaimer in the documentation and/or other materials provided
-* with the distribution.
-* * Neither the name of Robotiq, Inc. nor the names of its
-* contributors may be used to endorse or promote products derived
-* from this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*
-* Copyright (c) 2014, Robotiq, Inc
-*/
+ *
+ * Copyright (c) 2014, Robotiq, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * * Neither the name of Robotiq, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Copyright (c) 2014, Robotiq, Inc
+ * Modifications Copyright (c) 2017 READY Robotics
+ */
 
 /**
  * \file rq_sensor.cpp
@@ -40,99 +41,224 @@
  *  \maintainer Nicolas Lauzier <nicolas@robotiq.com>
  */
 
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "boost/bind.hpp"
+#include "geometry_msgs/WrenchStamped.h"
+#include "robotiq_force_torque_sensor/ft_sensor.h"
+#include "robotiq_force_torque_sensor/rq_sensor_state.h"
+#include "robotiq_force_torque_sensor/sensor_accessor.h"
 #include "ros/ros.h"
-#include "std_msgs/String.h"
 #include "std_msgs/Bool.h"
 #include "std_msgs/Empty.h"
-#include "geometry_msgs/WrenchStamped.h"
-#include "robotiq_force_torque_sensor/rq_sensor_state.h"
-#include "robotiq_force_torque_sensor/ft_sensor.h"
-#include "robotiq_force_torque_sensor/sensor_accessor.h"
+#include "std_msgs/String.h"
 
-static void decode_message_and_do(INT_8 const  * const buff, INT_8 * const ret);
-bool wait_for_other_connection(void);
-bool try_connection(void);
-static int max_retries_(5);
-void shutdown(void);
-void simulateSensor(ros::NodeHandle& nh);
-void launchRealSensor(ros::NodeHandle& nh);
-ros::Publisher sensor_pub;
-ros::Publisher wrench_pub;
-ros::Publisher watchdog_pub;
-ros::ServiceServer service;
-
-/**
- * \brief Decode the message received and do the associated action
- * \param buff message to decode
- * \param ret buffer containing the return value from a GET command
- */
-static void decode_message_and_do(INT_8 const  * const buff, INT_8 * const ret)
+class SensorBase
 {
-    INT_8 get_or_set[3];
-    INT_8 nom_var[4];
-
-    if(buff == NULL || strlen(buff) != 7)
+public:
+    SensorBase() : _connection_pub(_nh.advertise<std_msgs::Bool>("robotiq_force_torque_sensor_connected", 1))
     {
-        return;
+        ros::param::param<std::string>("~frame_id", _wrench_msg.header.frame_id, "robotiq_force_torque_frame_id");
     }
 
-    strncpy(get_or_set, &buff[0], 3);
-    strncpy(nom_var, &buff[4], strlen(buff) -3);
+    virtual ~SensorBase() = 0;
+    virtual bool makeConnection() = 0;
 
-    if(strstr(get_or_set, "GET"))
+    void Connect();
+    bool isConnected() const
     {
-        rq_state_get_command(nom_var, ret);
+        return _connection_msg.data;
     }
-    else if(strstr(get_or_set, "SET"))
+
+    void publishSensor();
+    void publishWatchdog()
     {
-        if(strstr(nom_var, "ZRO"))
-        {
-            rq_state_do_zero_force_flag();
-            strcpy(ret,"Done");
+        _watchdog_pub.publish(std_msgs::Empty());
+    }
+
+    void publishConnection()
+    {
+        _connection_pub.publish(_connection_msg);
+        ros::spinOnce();
+    }
+
+protected:
+    void setConnection(bool newState)
+    {
+        _connection_msg.data = newState;
+        publishConnection();
+    }
+
+private:
+    virtual bool _getSensorData(robotiq_force_torque_sensor::ft_sensor &msgStream) = 0;
+    bool _receiverCallback(robotiq_force_torque_sensor::sensor_accessor::Request &req, robotiq_force_torque_sensor::sensor_accessor::Response &res);
+    virtual void _decodeMessageAndDo(INT_8 const *const buff, INT_8 *const ret) = 0;
+
+    ros::NodeHandle _nh;
+    std_msgs::Bool _connection_msg;
+    ros::Publisher _connection_pub;
+
+    robotiq_force_torque_sensor::ft_sensor msgStream;
+    ros::Publisher _sensor_pub;
+
+    geometry_msgs::WrenchStamped _wrench_msg;
+    ros::Publisher _wrench_pub;
+    ros::Publisher _watchdog_pub;
+    ros::ServiceServer _service;
+};
+
+class SimulatedSensor : public SensorBase
+{
+public:
+    bool makeConnection() override
+    {
+        setConnection(true);
+        return true;
+    }
+
+private:
+    bool _getSensorData(robotiq_force_torque_sensor::ft_sensor &msgStream) override
+    {
+        msgStream.Fx = 0.0;
+        msgStream.Fy = 0.0;
+        msgStream.Fz = 0.0;
+        msgStream.Mx = 0.0;
+        msgStream.My = 0.0;
+        msgStream.Mz = 0.0;
+        // Keep publishing rate to 100Hz
+        ros::Duration(0.01).sleep();
+        return true;
+    }
+    void _decodeMessageAndDo(INT_8 const *const /*buff*/, INT_8 *const /*ret*/) override
+    {
+    }
+};
+
+class RealSensor : public SensorBase
+{
+public:
+    RealSensor() : _max_retries(5)
+    {
+        ros::param::param("~max_retries", _max_retries, 100);
+    }
+
+    bool makeConnection() override
+    {
+        uint8_t tries_left = 3;
+        while (!isConnected() && tries_left > 0) {
+            tries_left--;
+            if (_tryConnection()) {
+                setConnection(true);
+                return true;
+            }
         }
+        return false;
+    }
+
+private:
+    void _decodeMessageAndDo(INT_8 const *const buff, INT_8 *const ret) override;
+    bool _waitForOtherConnection(void);
+    bool _tryConnection();
+    bool _getSensorData(robotiq_force_torque_sensor::ft_sensor &msgStream) override;
+
+    // Would prefer a uint32_t but ROS doesn't provide unsigned values
+    int32_t _max_retries;
+};
+
+SensorBase::~SensorBase()
+{
+    if (isConnected()) {
+        setConnection(false);
+    }
+    ROS_INFO("Sensor Stopped");
+    // publishers send shutdown upon destruction if advertized
+}
+
+void SensorBase::Connect()
+{
+    if (makeConnection()) {
+        _sensor_pub = _nh.advertise<robotiq_force_torque_sensor::ft_sensor>("robotiq_force_torque_sensor", 512);
+        _wrench_pub = _nh.advertise<geometry_msgs::WrenchStamped>("robotiq_force_torque_wrench", 512);
+        _watchdog_pub = _nh.advertise<std_msgs::Empty>("/robotiq_ft300_force_torque_sensor/watchdog", 1);
+        _service = _nh.advertiseService("robotiq_force_torque_sensor_acc", &SensorBase::_receiverCallback, this);
     }
 }
 
-bool receiverCallback(robotiq_force_torque_sensor::sensor_accessor::Request& req,
-    robotiq_force_torque_sensor::sensor_accessor::Response& res)
+void SensorBase::publishSensor()
 {
-    ROS_INFO("I heard: [%s]",req.command.c_str());
+    robotiq_force_torque_sensor::ft_sensor msgStream;
+
+    if (_getSensorData(msgStream)) {
+        _sensor_pub.publish(msgStream);
+
+        _wrench_msg.header.stamp = ros::Time::now();
+        _wrench_msg.wrench.force.x = msgStream.Fx;
+        _wrench_msg.wrench.force.y = msgStream.Fy;
+        _wrench_msg.wrench.force.z = msgStream.Fz;
+        _wrench_msg.wrench.torque.x = msgStream.Mx;
+        _wrench_msg.wrench.torque.y = msgStream.My;
+        _wrench_msg.wrench.torque.z = msgStream.Mz;
+        _wrench_pub.publish(_wrench_msg);
+    }
+}
+
+bool SensorBase::_receiverCallback(robotiq_force_torque_sensor::sensor_accessor::Request &req,
+                                   robotiq_force_torque_sensor::sensor_accessor::Response &res)
+{
+    ROS_INFO("I heard: [%s]", req.command.c_str());
     INT_8 buffer[512];
-    decode_message_and_do((char*)req.command.c_str(), buffer);
+    _decodeMessageAndDo((char *)req.command.c_str(), buffer);
     res.res = buffer;
     ROS_INFO("I send: [%s]", res.res.c_str());
     return true;
 }
 
 /**
- * \fn bool wait_for_other_connection()
+ * \brief Decode the message received and do the associated action
+ * \param buff message to decode
+ * \param ret buffer containing the return value from a GET command
+ */
+void RealSensor::_decodeMessageAndDo(INT_8 const *const buff, INT_8 *const ret)
+{
+    INT_8 get_or_set[3];
+    INT_8 nom_var[4];
+
+    if (buff == NULL || strlen(buff) != 7) {
+        return;
+    }
+
+    strncpy(get_or_set, &buff[0], 3);
+    strncpy(nom_var, &buff[4], strlen(buff) - 3);
+
+    if (strstr(get_or_set, "GET")) {
+        rq_state_get_command(nom_var, ret);
+    }
+    else if (strstr(get_or_set, "SET")) {
+        if (strstr(nom_var, "ZRO")) {
+            rq_state_do_zero_force_flag();
+            strcpy(ret, "Done");
+        }
+    }
+}
+
+/**
+ * \fn bool waitForOtherConnection()
  * \brief Each second, checks for a sensor that has been connected
  */
-bool wait_for_other_connection(void)
+bool RealSensor::_waitForOtherConnection(void)
 {
-    INT_8 ret;
-    INT_8 count = 0;
+    uint8_t tries_left = 6;
 
-    while(ros::ok() && count < 6)
-    {
-        if (count % 2 == 0)
-        {
+    while (ros::ok() && tries_left > 0) {
+        if (tries_left-- % 2 == 0) {
             ROS_INFO("Waiting for sensor connection...");
         }
-        usleep(10000); //Attend 1 seconde.
-
-        ret = rq_sensor_state(max_retries_);
-        if(ret == 0)
-        {
+        if (rq_sensor_state(_max_retries) == 0) {
             ROS_INFO("Sensor connected!");
             return true;
         }
-        count++;
-        ros::spinOnce();
+        ros::Duration(1.0).sleep();
     }
     return false;
 }
@@ -141,28 +267,19 @@ bool wait_for_other_connection(void)
  * \fn bool try_connection()
  * \brief A helper function to avoid repeated code
  */
-bool try_connection(void)
+bool RealSensor::_tryConnection()
 {
-    INT_8 ret;
-    ret = rq_sensor_state(max_retries_);
-    if(ret == -1)
-    {
-        if (!wait_for_other_connection())
-        {
-            return false;
-        }
+    if (rq_sensor_state(_max_retries) != -1) {
+        return true;
     }
-    return true;
+    return _waitForOtherConnection();
 }
 
-/**
- * \fn void get_data(void)
- * \brief Builds the message with the force/torque data
- * \return ft_sensor updated with the latest data
- */
-static robotiq_force_torque_sensor::ft_sensor get_data(void)
+bool RealSensor::_getSensorData(robotiq_force_torque_sensor::ft_sensor &msgStream)
 {
-    robotiq_force_torque_sensor::ft_sensor msgStream;
+    if (!_tryConnection() || rq_sensor_get_current_state() != RQ_STATE_RUN) {
+        return false;
+    }
 
     msgStream.Fx = rq_state_get_received_data(0);
     msgStream.Fy = rq_state_get_received_data(1);
@@ -171,206 +288,41 @@ static robotiq_force_torque_sensor::ft_sensor get_data(void)
     msgStream.My = rq_state_get_received_data(4);
     msgStream.Mz = rq_state_get_received_data(5);
 
-    return msgStream;
+    return rq_state_got_new_message();
 }
-
-void simulateSensor(ros::NodeHandle& nh) 
-{
-    ros::Publisher connection_pub = nh.advertise<std_msgs::Bool>("robotiq_force_torque_sensor_connected", 1);
-    sensor_pub = nh.advertise<robotiq_force_torque_sensor::ft_sensor>("robotiq_force_torque_sensor", 512);
-    wrench_pub = nh.advertise<geometry_msgs::WrenchStamped>("robotiq_force_torque_wrench", 512);
-    watchdog_pub = nh.advertise<std_msgs::Empty>("/robotiq_ft300_force_torque_sensor/watchdog", 1);
-    service = nh.advertiseService("robotiq_force_torque_sensor_acc", receiverCallback);
-
-    std_msgs::Bool connection_msg;
-    robotiq_force_torque_sensor::ft_sensor msgStream;
-    geometry_msgs::WrenchStamped wrenchMsg;
-    std_msgs::Empty watchdog_msg;
-    ros::param::param<std::string>("~frame_id", wrenchMsg.header.frame_id, "robotiq_force_torque_frame_id");
-    INT_32 publish_count = 0;
-
-
-    // Publish the connection state
-    connection_msg.data = true;
-    connection_pub.publish(connection_msg);
-    ros::spinOnce();
-
-    ROS_INFO("Starting Sensor");
-
-    msgStream.Fx = 0.0;
-    msgStream.Fy = 0.0;
-    msgStream.Fz = 0.0;
-    msgStream.Mx = 0.0;
-    msgStream.My = 0.0;
-    msgStream.Mz = 0.0;
-    wrenchMsg.wrench.force.x = msgStream.Fx;
-    wrenchMsg.wrench.force.y = msgStream.Fy;
-    wrenchMsg.wrench.force.z = msgStream.Fz;
-    wrenchMsg.wrench.torque.x = msgStream.Mx;
-    wrenchMsg.wrench.torque.y = msgStream.My;
-    wrenchMsg.wrench.torque.z = msgStream.Mz;
-
-    while(ros::ok()) {
-        sensor_pub.publish(msgStream);
-        wrenchMsg.header.stamp = ros::Time::now();
-        wrench_pub.publish(wrenchMsg);
-
-        // Publish the connection state every 1000 iterations
-        if (publish_count % 10 == 0) {
-            watchdog_pub.publish(watchdog_msg);
-        }
-
-        if (publish_count == 1000) {
-            connection_msg.data = true;
-            connection_pub.publish(connection_msg);
-            publish_count = 0;
-        }
-        publish_count++;
-        // Keep publishing rate to 100Hz
-        ros::Duration(0.01).sleep();
-        ros::spinOnce();
-    }
-
-    ROS_INFO("Sensor Stopped");
-
-    // Publish the connection state
-    connection_msg.data = false;
-    connection_pub.publish(connection_msg);
-    ros::spinOnce();
-
-    // unregister publishers
-    sensor_pub.shutdown();
-    wrench_pub.shutdown();
-    watchdog_pub.shutdown();
-    service.shutdown();
-    connection_pub.shutdown();
-}
-
-
-void launchRealSensor(ros::NodeHandle& nh)
-{
-    std_msgs::Bool connection_msg;
-    ros::param::param<int>("~max_retries", max_retries_, 100);
-
-    INT_8 bufStream[512];
-    INT_32 publish_count = 0;
-    robotiq_force_torque_sensor::ft_sensor msgStream;
-    bool connected = false;
-    uint8_t created_publishers = 0;
-
-    //If we can't initialize, we return an error
-    connected = try_connection();
-
-    //Reads basic info on the sensor
-    if (connected) {
-        connected = try_connection();
-    }
-
-    //Starts the stream
-    if (connected) {
-        connected = try_connection();
-    }
-
-    ros::Publisher connection_pub = nh.advertise<std_msgs::Bool>("robotiq_force_torque_sensor_connected", 1);
-    if (connected) {
-        sensor_pub = nh.advertise<robotiq_force_torque_sensor::ft_sensor>("robotiq_force_torque_sensor", 512);
-        wrench_pub = nh.advertise<geometry_msgs::WrenchStamped>("robotiq_force_torque_wrench", 512);
-        watchdog_pub = nh.advertise<std_msgs::Empty>("/robotiq_ft300_force_torque_sensor/watchdog", 1);
-        service = nh.advertiseService("robotiq_force_torque_sensor_acc", receiverCallback);
-        created_publishers = 1;
-    }
-
-    //std_msgs::String msg;
-    geometry_msgs::WrenchStamped wrenchMsg;
-    std_msgs::Empty watchdog_msg;
-    ros::param::param<std::string>("~frame_id", wrenchMsg.header.frame_id, "robotiq_force_torque_frame_id");
-
-    // Publish the connection state
-    connection_msg.data = connected;
-    connection_pub.publish(connection_msg);
-    ros::spinOnce();
-
-    if (connected)
-    {
-        ROS_INFO("Starting Sensor");
-    }
-
-    while(ros::ok() && connected)
-    {
-        connected = try_connection();
-
-        if(rq_sensor_get_current_state() == RQ_STATE_RUN)
-        {
-            strcpy(bufStream,"");
-            msgStream = get_data();
-
-            if(rq_state_got_new_message())
-            {
-                sensor_pub.publish(msgStream);
-
-                // compose WrenchStamped Msg
-                wrenchMsg.header.stamp = ros::Time::now();
-                wrenchMsg.wrench.force.x = msgStream.Fx;
-                wrenchMsg.wrench.force.y = msgStream.Fy;
-                wrenchMsg.wrench.force.z = msgStream.Fz;
-                wrenchMsg.wrench.torque.x = msgStream.Mx;
-                wrenchMsg.wrench.torque.y = msgStream.My;
-                wrenchMsg.wrench.torque.z = msgStream.Mz;
-                wrench_pub.publish(wrenchMsg);
-            }
-        }
-
-        // Publish the connection state every 1000 iterations
-        if (publish_count % 10 == 0)
-        {
-            watchdog_pub.publish(watchdog_msg);
-        }
-
-        if (publish_count == 1000)
-        {
-            connection_msg.data = connected;
-            connection_pub.publish(connection_msg);
-            publish_count = 0;
-        }
-        publish_count++;
-        ros::spinOnce();
-    }
-
-    if (!connected)
-    {
-        connection_msg.data = connected;
-        connection_pub.publish(connection_msg);
-        ros::spinOnce();
-    }
-
-    ROS_INFO("Sensor Stopped");
-    if (created_publishers)
-    {
-        // unregister publishers
-        sensor_pub.shutdown();
-        wrench_pub.shutdown();
-        watchdog_pub.shutdown();
-        service.shutdown();
-    }
-
-    // unregister
-    connection_pub.shutdown();
-}
-
 
 int main(int argc, char **argv)
 {
     ros::init(argc, argv, "robotiq_force_torque_sensor");
-    ROS_INFO("Trying to Start Sensor");
-    ros::NodeHandle n;
+
+    std::unique_ptr<SensorBase> sensor_ptr;
 
     bool simulated;
     ros::param::param<bool>("/simulate_robot", simulated, false);
     if (simulated) {
-        simulateSensor(n);
+        ROS_INFO("Trying to Start Simulated Robotiq Sensor");
+        sensor_ptr.reset(new SimulatedSensor);
     }
     else {
-        launchRealSensor(n);
+        ROS_INFO("Trying to Start Robotiq FT300 Sensor");
+        sensor_ptr.reset(new RealSensor);
     }
+
+    uint32_t publish_count = 0;
+
+    sensor_ptr->Connect();
+    while (ros::ok() && sensor_ptr->isConnected()) {
+        sensor_ptr->publishSensor();
+
+        if (publish_count % 10 == 0) {
+            sensor_ptr->publishWatchdog();
+        }
+        if (publish_count == 1000) {
+            sensor_ptr->publishConnection();
+            publish_count = 0;
+        }
+        publish_count++;
+    }
+
     return 0;
 }

--- a/robotiq_force_torque_sensor/package.xml
+++ b/robotiq_force_torque_sensor/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>robotiq_force_torque_sensor</name>
   <version>2.1.0</version>
   <description>Package for reading data from a Robotiq Force Torque Sensor</description>
@@ -11,15 +11,12 @@
 
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>bondcpp</build_depend>
-  <run_depend>bondcpp</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
-
+  <depend>bondcpp</depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>launch_manager_interface</depend>
+  <exec_depend>message_runtime</exec_depend>
 
   <export>
 


### PR DESCRIPTION
First set of changes is "Reduce duplicated logic, compile with C++11", so that support for initial config should appear in one location rather than several.